### PR TITLE
Make stats and string matching case-insensitive

### DIFF
--- a/collectors/names_collector.go
+++ b/collectors/names_collector.go
@@ -3,6 +3,7 @@ package collectors
 import (
 	"bufio"
 	"os"
+	"strings"
 
 	"github.com/DRuggeri/bind_query_exporter/util"
 	"github.com/prometheus/client_golang/prometheus"

--- a/collectors/names_collector.go
+++ b/collectors/names_collector.go
@@ -3,7 +3,7 @@ package collectors
 import (
 	"bufio"
 	"os"
-    "strings"
+	"strings"
 
 	"github.com/DRuggeri/bind_query_exporter/util"
 	"github.com/prometheus/client_golang/prometheus"

--- a/collectors/names_collector.go
+++ b/collectors/names_collector.go
@@ -3,7 +3,7 @@ package collectors
 import (
 	"bufio"
 	"os"
-	"strings"
+    "strings"
 
 	"github.com/DRuggeri/bind_query_exporter/util"
 	"github.com/prometheus/client_golang/prometheus"
@@ -100,9 +100,9 @@ func NewNamesCollector(namespace string, sender *chan string, matcher *util.LogM
 			if info.Matched {
 				totalMetric.Add(1)
 				if config.captureClient {
-					namesMetric.WithLabelValues(strings.ToLower(info.QueryName), info.QueryClient).Add(1)
+					namesMetric.WithLabelValues(info.QueryName, info.QueryClient).Add(1)
 				} else {
-					namesMetric.WithLabelValues(strings.ToLower(info.QueryName)).Add(1)
+					namesMetric.WithLabelValues(info.QueryName).Add(1)
 				}
 			}
 		}
@@ -127,7 +127,7 @@ func makeList(fileName string) (map[string]bool, error) {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		log.Debugln("  ", scanner.Text())
-		result[scanner.Text()] = true
+		result[strings.ToLower(scanner.Text())] = true
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/collectors/names_collector.go
+++ b/collectors/names_collector.go
@@ -99,9 +99,9 @@ func NewNamesCollector(namespace string, sender *chan string, matcher *util.LogM
 			if info.Matched {
 				totalMetric.Add(1)
 				if config.captureClient {
-					namesMetric.WithLabelValues(info.QueryName, info.QueryClient).Add(1)
+					namesMetric.WithLabelValues(strings.ToLower(info.QueryName), info.QueryClient).Add(1)
 				} else {
-					namesMetric.WithLabelValues(info.QueryName).Add(1)
+					namesMetric.WithLabelValues(strings.ToLower(info.QueryName)).Add(1)
 				}
 			}
 		}

--- a/util/LogMatcher.go
+++ b/util/LogMatcher.go
@@ -41,7 +41,7 @@ func (m LogMatcher) ExtractInfo(line string) LogMatch {
 	if len(match) > 0 {
 		result.Matched = true
 		result.QueryClient = match[1]
-		result.QueryName = match[2]
+		result.QueryName = strings.ToLower(match[2])
 		result.QueryType = match[3]
 
 		/* Check if we should avoid a DNS lookup since this name is not


### PR DESCRIPTION
New: Strings read from the inc/excl files are rendered lowercase when adding to the internal lists. Names from log are lowercased at ingestion.

As it was, stats were produced for each variation of each name, in a case sensitive manner. This balloons the stats massively and makes it less intuitive to make per-name/domain statistics and monitoring. It is assumed that in the vast majority of cases, case is not interesting.